### PR TITLE
Simplify code for finding a sampling plan

### DIFF
--- a/R/code_generic.R
+++ b/R/code_generic.R
@@ -95,74 +95,44 @@ find.plan <- function(PRP, CRP,
   if (type == "binomial") {
     c <- 0
     n <- c+1
-    pa1 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=PRP[1])
-    pa2 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=CRP[1])
 
-    while (pa2 > CRP[2]) {
-      while (pa1 >= PRP[2]) {
-        n <- n+1
-        pa1 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=PRP[1])
-        pa2 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=CRP[1])
-        if(pa2 <= CRP[2])
-          break
-      }
-      if(pa2 <= CRP[2] & pa1 >= PRP[2])
-          break
-      ## No need to reset n - this can stay where it is to speed up
-      ## finding a solution.
-      c <- c+1
-      pa1 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=PRP[1])
-      pa2 <- calc.OCbinomial(n=n,c=c,r=c+1,pd=CRP[1])
+    repeat {
+      if(calc.OCbinomial(n=n,c=c,r=c+1,pd=CRP[1]) > CRP[2])
+        n <- n + 1
+      else if(calc.OCbinomial(n=n,c=c,r=c+1,pd=PRP[1]) < PRP[2])
+        c <- c + 1
+      else
+        break
     }
     return(list(n=n, c=c, r=c+1))
   }
-  ## Attributes Sampling Plan - Binomial distribution
+  ## Attributes Sampling Plan - Hypergeometric distribution
   if (type == "hypergeom") {
     c <- 0
     n <- c+1
-    pa1 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=PRP[1]*N)
-    pa2 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=CRP[1]*N)
 
-    while (pa2 > CRP[2]) {
-      while (pa1 >= PRP[2]) {
-        n <- n+1
-        pa1 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=PRP[1]*N)
-        pa2 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=CRP[1]*N)
-        if(pa2 <= CRP[2])
-          break
-      }
-      if(pa2 <= CRP[2] & pa1 >= PRP[2])
-          break
-      ## No need to reset n - this can stay where it is to speed up
-      ## finding a solution.
-      c <- c+1
-      pa1 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=PRP[1]*N)
-      pa2 <- calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=CRP[1]*N)
+    repeat {
+      if(calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=CRP[1]*N) > CRP[2])
+        n <- n + 1
+      else if(calc.OChypergeom(n=n,c=c,r=c+1,N=N,D=PRP[1]*N) < PRP[2])
+        c <- c + 1
+      else
+        break
     }
     return(list(n=n, c=c, r=c+1))
   }
-  ## Attributes Sampling Plan - Binomial distribution
+  ## Attributes Sampling Plan - Poisson distribution
   if (type == "poisson") {
     c <- 0
     n <- c+1
-    pa1 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=PRP[1])
-    pa2 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=CRP[1])
 
-    while (pa2 > CRP[2]) {
-      while (pa1 >= PRP[2]) {
-        n <- n+1
-        pa1 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=PRP[1])
-        pa2 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=CRP[1])
-        if(pa2 <= CRP[2])
-          break
-      }
-      if(pa2 <= CRP[2] & pa1 >= PRP[2])
-          break
-      ## No need to reset n - this can stay where it is to speed up
-      ## finding a solution.
-      c <- c+1
-      pa1 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=PRP[1])
-      pa2 <- calc.OCpoisson(n=n,c=c,r=c+1,pd=CRP[1])
+    repeat {
+      if(calc.OCpoisson(n=n,c=c,r=c+1,pd=CRP[1]) > CRP[2])
+        n <- n + 1
+      else if(calc.OCpoisson(n=n,c=c,r=c+1,pd=PRP[1]) < PRP[2])
+        c <- c + 1
+      else
+        break
     }
     return(list(n=n, c=c, r=c+1))
   }

--- a/R/code_twoclass.R
+++ b/R/code_twoclass.R
@@ -216,13 +216,14 @@ calc.OChypergeom <- function(n,c,r,N,D)
   ## when the number nonconforming is D[i]
 
   pa <- matrix(0, length(D), dim2)
+  nd <- outer(D, 0:(rMax - 1), "-")
 
   while (n > 0) {
     if (boundaries$lower[n] >= 0)
       pa[, 1:(1 + boundaries$lower[n])] <- 1
     pa[, (1 + boundaries$upper[n]):dim2] <- 0
     n <- n - 1
-    p <- outer(D, 0:(rMax - 1), "-") / (N - n)
+    p <- nd / (N - n)
     pa[, -dim2] <- (1 - p) * pa[, -dim2] + p * pa[, -1]
   }
   pa[, 1]

--- a/R/code_twoclass.R
+++ b/R/code_twoclass.R
@@ -146,7 +146,7 @@ setClass("OCpoisson",
 ## other functions are helpers only
 ## ----------------------------------------------------------------------
 
-OC2c <- function(n,c,r=if (length(c)==1) c+1 else NULL,
+OC2c <- function(n,c,r=1+rep(c[length(c)],length(c)),
                type=c("binomial","hypergeom", "poisson"), ...){
   ## Decide on what 'type' to use
   type <- match.arg(type)

--- a/man/OC2c.Rd
+++ b/man/OC2c.Rd
@@ -17,7 +17,7 @@
 \description{ The preferred way of creating new objects from the family
   of \code{"OC2c"} classes.}
 
-\usage{OC2c(n,c,r=if (length(c)==1) c+1 else NULL,
+\usage{OC2c(n,c,r=1+rep(c[length(c)],length(c)),
   type=c("binomial","hypergeom", "poisson"), ...) }
 
 \arguments{
@@ -47,8 +47,8 @@
   }
   
   The first and second forms use a default \code{type} of
-  "binomial". The first form can calculate \code{r} \emph{only} when
-  \code{n} and \code{c} are of length 1.
+  "binomial". The first form calculates \code{r} as a vector of values
+  all equal to the last acceptance number plus one.
 
   The second form provides a the proportion of defectives, \code{pd}, for
   which the OC function should be calculated (default is \code{pd=seq(0,


### PR DESCRIPTION
```
* R/code_generic.R (find.plan): simplify the code for finding an
      acceptance-sampling plan for attributes, in the binomial,
      hypergeometric, and Poisson cases.
```

Hi Andreas!

Many thanks for your efforts on providing OC curves and other tools for acceptance sampling plans!

I'm teaching a course on spc/qi, and finding your package incredibly useful. The find.plan tool is a real winner with my class--they really like to have tools to assist in implementing specific programs.

I used find.plan to reproduce a problem described by Montgomery in his book "Introduction to Statistical Quality Control", with:
find.plan(PRP=c(0.01, 0.95), CRP=c(0.06, 0.10))
and seeing a different solution from Montgomery's, I delved into the code. I'm convinced that find.plan() has the correct solution, and that Montgomery's (obtained from a nomogram) doesn't quite meet the constraints.

I found the search code confusing, and to make sure I understand the principles I recoded it, as in this pr. I believe it finds the same plans, and in around one half the execution time, but I admit that's in only a few tests. I'd be glad if you'd consider this contribution.

Best regards,

Peter Bloomfield
